### PR TITLE
feat: Add profile modal to student dashboard

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '../lib/firebase';
+import { ProfileModal } from './student';
 
 const Navbar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+  const [user] = useAuthState(auth);
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -167,12 +171,16 @@ const Navbar = () => {
             ))}
             
             {/* Login Button */}
-            <button 
-              onClick={() => navigate('/auth')}
-              className="bg-vibrant-orange text-white px-6 py-2 rounded-full font-medium font-poppins transition-all duration-300 hover:bg-deep-blue hover:scale-105 shadow-md hover:shadow-lg"
-            >
-              Login
-            </button>
+            {user ? (
+              <ProfileModal studentId={user.uid} />
+            ) : (
+              <button
+                onClick={() => navigate('/auth')}
+                className="bg-vibrant-orange text-white px-6 py-2 rounded-full font-medium font-poppins transition-all duration-300 hover:bg-deep-blue hover:scale-105 shadow-md hover:shadow-lg"
+              >
+                Login
+              </button>
+            )}
           </div>
 
           {/* Mobile menu button */}
@@ -202,15 +210,19 @@ const Navbar = () => {
             
             {/* Mobile Login Button */}
             <div className="pt-4 pb-2">
-              <button 
-                onClick={() => {
-                  navigate('/auth');
-                  setIsMenuOpen(false);
-                }}
-                className="w-full bg-vibrant-orange text-white px-6 py-3 rounded-full font-medium font-poppins transition-all duration-300 hover:bg-deep-blue shadow-md hover:shadow-lg"
-              >
-                Login
-              </button>
+              {user ? (
+                <ProfileModal studentId={user.uid} />
+              ) : (
+                <button
+                  onClick={() => {
+                    navigate('/auth');
+                    setIsMenuOpen(false);
+                  }}
+                  className="w-full bg-vibrant-orange text-white px-6 py-3 rounded-full font-medium font-poppins transition-all duration-300 hover:bg-deep-blue shadow-md hover:shadow-lg"
+                >
+                  Login
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/StudentHeader.tsx
+++ b/src/components/StudentHeader.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Trophy, Flame, ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { ProfileModal } from './student';
 
 interface StudentHeaderProps {
   /**
@@ -28,6 +29,10 @@ interface StudentHeaderProps {
    * Student's current daily-streak – if omitted, the points / streak cluster will be hidden.
    */
   currentStreak?: number;
+  /**
+   * The student's ID.
+   */
+  studentId?: string;
 }
 
 const StudentHeader: React.FC<StudentHeaderProps> = ({
@@ -36,6 +41,7 @@ const StudentHeader: React.FC<StudentHeaderProps> = ({
   backLabel = 'Back to Dashboard',
   totalPoints,
   currentStreak,
+  studentId,
 }) => {
   const navigate = useNavigate();
 
@@ -87,33 +93,36 @@ const StudentHeader: React.FC<StudentHeaderProps> = ({
           </div>
 
           {/* Right section – Stats (only if both values are provided) */}
-          {totalPoints !== undefined && currentStreak !== undefined && (
-            <motion.div
-              className="flex items-center gap-4"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ delay: 0.2 }}
-            >
-              <div className="flex items-center gap-2 bg-gradient-to-r from-yellow-100 to-orange-100 px-4 py-2 rounded-full">
-                <Trophy className="w-5 h-5 text-yellow-600" />
-                <span className="font-bold text-yellow-800">{totalPoints} Points</span>
-              </div>
-
-              <div
-                className={`flex items-center gap-2 bg-gradient-to-r ${getStreakColor(
-                  currentStreak
-                )} px-4 py-2 rounded-full text-white`}
+          <div className="flex items-center gap-4">
+            {totalPoints !== undefined && currentStreak !== undefined && (
+              <motion.div
+                className="flex items-center gap-4"
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.2 }}
               >
-                <motion.div
-                  animate={{ scale: [1, 1.2, 1], rotate: [0, 10, -10, 0] }}
-                  transition={{ duration: 2, repeat: Infinity }}
+                <div className="flex items-center gap-2 bg-gradient-to-r from-yellow-100 to-orange-100 px-4 py-2 rounded-full">
+                  <Trophy className="w-5 h-5 text-yellow-600" />
+                  <span className="font-bold text-yellow-800">{totalPoints} Points</span>
+                </div>
+
+                <div
+                  className={`flex items-center gap-2 bg-gradient-to-r ${getStreakColor(
+                    currentStreak
+                  )} px-4 py-2 rounded-full text-white`}
                 >
-                  <Flame className="w-5 h-5" />
-                </motion.div>
-                <span className="font-bold">{currentStreak} Day Streak</span>
-              </div>
-            </motion.div>
-          )}
+                  <motion.div
+                    animate={{ scale: [1, 1.2, 1], rotate: [0, 10, -10, 0] }}
+                    transition={{ duration: 2, repeat: Infinity }}
+                  >
+                    <Flame className="w-5 h-5" />
+                  </motion.div>
+                  <span className="font-bold">{currentStreak} Day Streak</span>
+                </div>
+              </motion.div>
+            )}
+            {studentId && <ProfileModal studentId={studentId} />}
+          </div>
         </div>
       </div>
     </motion.header>

--- a/src/components/student/ProfileModal.tsx
+++ b/src/components/student/ProfileModal.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { auth, db } from '../../lib/firebase';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '../ui/dialog';
+import { Button } from '../ui/button';
+import { User } from 'lucide-react';
+
+interface ProfileModalProps {
+  studentId: string;
+}
+
+const ProfileModal: React.FC<ProfileModalProps> = ({ studentId }) => {
+  const [studentData, setStudentData] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStudentData = async () => {
+      try {
+        const studentRef = doc(db, 'students', studentId);
+        const studentSnap = await getDoc(studentRef);
+        if (studentSnap.exists()) {
+          setStudentData(studentSnap.data());
+        }
+      } catch (error) {
+        console.error('Error fetching student data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (studentId) {
+      fetchStudentData();
+    }
+  }, [studentId]);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <User className="h-6 w-6" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Student Profile</DialogTitle>
+        </DialogHeader>
+        {loading ? (
+          <p>Loading...</p>
+        ) : studentData ? (
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Name</p>
+              <p className="col-span-3">{studentData.name}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Class</p>
+              <p className="col-span-3">{studentData.grade}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Gender</p>
+              <p className="col-span-3">{studentData.gender || 'N/A'}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Age</p>
+              <p className="col-span-3">{studentData.age || 'N/A'}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Parent</p>
+              <p className="col-span-3">{studentData.parentInfo?.fatherName || 'N/A'}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">WhatsApp</p>
+              <p className="col-span-3">{studentData.phone}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Email</p>
+              <p className="col-span-3">{studentData.email}</p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Address</p>
+              <p className="col-span-3">
+                {studentData.schoolInfo?.address?.street}, {studentData.schoolInfo?.address?.city},{' '}
+                {studentData.schoolInfo?.address?.pincode}
+              </p>
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <p className="col-span-1 font-semibold">Student ID</p>
+              <p className="col-span-3">{studentData.studentId}</p>
+            </div>
+          </div>
+        ) : (
+          <p>No data available.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProfileModal;

--- a/src/components/student/index.tsx
+++ b/src/components/student/index.tsx
@@ -1,0 +1,1 @@
+export { default as ProfileModal } from './ProfileModal';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -412,7 +412,8 @@ const Dashboard = () => {
       <StudentHeader 
         showBackButton={false} 
         totalPoints={studentData.totalPoints} 
-        currentStreak={studentData.streakCount} 
+        currentStreak={studentData.streakCount}
+        studentId={user?.uid}
       />
 
       {/* Main Content */}


### PR DESCRIPTION
This commit adds a new profile modal to the student dashboard. The modal displays your name, class, gender, age, parent details, WhatsApp number, email, address, and student ID.

The profile modal is accessible from a new profile icon in the student header and the main navbar. Your data is fetched from Firestore based on your user ID.